### PR TITLE
Changes win condition for telephone match

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -27,8 +27,8 @@ $(document).ready(function(){
       hint: "Using the pipe character allows you to specify OR like so: (a|b)"
     },
     { rules: "Daenerys is in trouble. Match the valid phone numbers so Tyrion can call and warn her!",
-      words: ["333-5554-2993", "516-555-3722", "440-22d-9393", "917-555-9830", "7999-3333", "8-9-9"],
-      win_condition: ["516-555-3722", "917-555-9830"],
+      words: ["333-5554-2993", "516-535-3722", "440-22d-9393", "917-555-9830", "7999-3333", "8-9-9"],
+      win_condition: ["516-535-3722", "917-555-9830"],
       hint: "Remember the curly brackets {} allow you to specify a specific number of matched characters."
     },
     { rules: "Passwords to TheDreadFort.com must be secure! Match all passwords that include at least 1 non alphanumeric character.",


### PR DESCRIPTION
With the current version, a user can pass this round by simply checking for '555' in the middle section of the phone number, but the round should check to see if it is a valid phone number. I changed the win condition so that the two passing telephone numbers have different middle sections and therefore the user must actually pass a valid telephone number rather than just checking for '555' in the middle section.
